### PR TITLE
player object moves between floors

### DIFF
--- a/include/character.h
+++ b/include/character.h
@@ -54,6 +54,7 @@ class Character : public GameObject
    void updateCollisions( const std::vector<Rectangle> colliders );
 
    Vector2 getPosition( );
+   void setPosition(Vector2 newPos);
 
    void moveToTarget( Vector2 target, float distanceMaintained, std::vector<Rectangle> colliders );
 

--- a/include/object.h
+++ b/include/object.h
@@ -2,6 +2,7 @@
 
 #include <cstdio>
 #include <vector>
+#include <map>
 #include "raylib.h"
 
 
@@ -10,8 +11,6 @@ private:
     int id;
 
 public:
-
-    // gameObject() : id(0) {} // Default constructor <<<<<<< combat-character-copy
 
     GameObject() {}
     GameObject(int id) {
@@ -28,8 +27,6 @@ public:
     // Setters
     void setId(int id);
 
-
-    // virtual void onTick(); <<<<<<< combat-character-copy
     virtual void onTick(const std::vector<Rectangle> collidables);
     // TODO 00
 
@@ -44,17 +41,14 @@ private:
 public:
 
     int numberOfObjects;
-    int nextId;
+    static int nextId; //this is shared between all object handlers (each floor has one)
 
-    // std::vector<class gameObject *> allObjects; <<<<<<< combat-character-copy
-    // objectHandler() { <<<<<<< combat-character-copy
-    std::vector<class GameObject *> allObjects;
+    std::map<int, GameObject* > allObjects;
 
 public:
     ObjectHandler() 
     {
         this->numberOfObjects = 0;
-        this->nextId = 0;
     }
     ~ObjectHandler() 
     {
@@ -63,9 +57,9 @@ public:
 
     void tickAll(const std::vector<Rectangle> collidables);
     void renderAll();
+    void transferObject(int objId, ObjectHandler& newHandler);
     class GameObject *getObject(int id);
     class GameObject *createObject();
     class Player *createPlayer(Vector2 position, Vector2 size, int speed);
-// }; <<<<<<< combat-character-copy
     class Enemy* createEnemy( Vector2 position, Vector2 size, int speed );
 };

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -161,6 +161,12 @@ Vector2 Character::getPosition( )
    return position;
 }
 
+void Character::setPosition(Vector2 newPos)
+{
+    position.x = newPos.x;
+    position.y = newPos.y;
+}
+
 float Character::getTargetDistance( )
 {
    float dx = position.x - target.x;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ Devon, everyone else who worked on this file put ur names here too so Vicki can 
 
 constexpr int FPS = 60;
 constexpr int PLAYER_SPEED = 300;
-const int NUM_OF_FLOORS = 4;
+const int NUM_OF_FLOORS = 4; //the number of floors in the game
 
 ScreenHandler screenHandler = ScreenHandler( );
 // IMPORTANT! These are different versions of the camera with different zoom levels, uncomment the one you want.
@@ -30,7 +30,7 @@ CustomCamera mainCamera = CustomCamera( Vector2 { 1280, 720.0f }, 1.0f );
 
 std::unordered_map<std::string, Texture2D> textureMap = {};
 
-void changeFloor(std::vector<Sprite>& wallSprites, Floor* floors[NUM_OF_FLOORS], int floorOn);  //loads the wall sprites for the new floor
+void changeFloor(std::vector<Sprite>& wallSprites, Floor* floors[NUM_OF_FLOORS], int& floorOn, int changeVal);  //changes the floor that the player is on
 
 int main( )
 {
@@ -47,7 +47,7 @@ int main( )
 
     // Create a player so we can see it tick, and see it on screen
     Vector2 playerSpawnPosition = floors[floorOn]->getPlayerSpawn();
-    floors[floorOn]->getObjHandler()->createPlayer(playerSpawnPosition, {TILE_SIZE, TILE_SIZE}, 300);
+    floors[floorOn]->getObjHandler()->createPlayer(playerSpawnPosition, { TILE_SIZE, TILE_SIZE }, 300);
 
     std::vector<Sprite> wallSprites = {};                    //is changed when player changes floors
     for (Rectangle wall : floors[floorOn]->getWalls())       //put the wall sprites for the starting floor
@@ -69,8 +69,8 @@ int main( )
 
             also changing floors needs to only be possible when player is on a ladder, up or down
             */
-            floorOn += 1;
-            changeFloor(wallSprites,floors,floorOn);
+            //floorOn += 1;
+            changeFloor(wallSprites,floors,floorOn, 1);
             std::cout << "\n moved from floor " << floorOn -1 << " to " << floorOn;
         }
 
@@ -88,9 +88,26 @@ int main( )
     return 0;
 }
 
-//loads the wall sprites for the new floor. prob will be added to -devon
-void changeFloor(std::vector<Sprite>& wallSprites, Floor* floors[NUM_OF_FLOORS], int floorOn)
+/*------------------------------------------------------------------------------------------------------------------
+* changeFloor() changes the players current floor
+* - devon
+* param vector<Sprite>& wallSprites: sprites of the walls. edited by this function
+* param Floor* floors[NUM_OF_FLOORS]: array of all the floors in the game
+* param int& floorOn: the index of the floor the player is currently on. edited by this function
+* param int changeVal: the amount by which the floor index is changed. exe -1 is down a floor, and 1 is up a floor
+* return: the data in wallSprites and floorOn is altered
+------------------------------------------------------------------------------------------------------------------*/
+void changeFloor(std::vector<Sprite>& wallSprites, Floor* floors[NUM_OF_FLOORS], int& floorOn, int changeVal)
 {
+    //transfer player to new object handler
+    ObjectHandler* oldHandler = floors[floorOn]->getObjHandler();
+    floorOn+= changeVal;
+    ObjectHandler* newHandler = floors[floorOn]->getObjHandler();
+    oldHandler->transferObject(0, *newHandler); //player id is always 0
+
+    //TODO set player location to the new floors ladderUp
+
+    //make new wall sprites
     wallSprites.clear();
     for (Rectangle wall : floors[floorOn]->getWalls())
     {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -24,14 +24,31 @@ void GameObject::onRender() {
 // ----- ObjectHandler -----
 
 class GameObject *ObjectHandler::createObject() {
-    class GameObject *newObject = new GameObject(this->nextId++);
-    this->allObjects.push_back(newObject);
+    class GameObject *newObject = new GameObject(nextId++);
+    allObjects[newObject->getId()] = newObject; //add <id, object*> to the map
     this->numberOfObjects++;
     return newObject;
 }
 
 class GameObject *ObjectHandler::getObject(int id) {
     return this->allObjects[id];
+}
+
+/*------------------------------------------------------------------------------------------------------------------
+* transferObject() moves an object from this handler to another object handler
+* - devon
+* param int objId: id of the object being transfered
+* param ObjectHandler &newHandler: the handler the object is being transfered to
+* return: alters data in this and newHandler
+------------------------------------------------------------------------------------------------------------------*/
+void ObjectHandler::transferObject(int objId, ObjectHandler &newHandler)
+{
+    //this assumes the object exists in the current handler, if it doesn't it gives an error when ticking
+    newHandler.allObjects[objId] = this->getObject(objId);
+    newHandler.numberOfObjects++;
+
+    this->allObjects.erase(objId);
+    this->numberOfObjects--;
 }
 
 void ObjectHandler::tickAll(const std::vector<Rectangle> collidables) {
@@ -47,3 +64,5 @@ void ObjectHandler::renderAll()
         this->allObjects[x]->onRender();
     }
 }
+
+int ObjectHandler::nextId = 1;  //this is shared between all object handlers. starts at 1 bc the player is always 0

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -45,8 +45,8 @@ void Player::onRender()
 // Define the Player create function in the object handler
 class Player* ObjectHandler::createPlayer( Vector2 position, Vector2 size, int speed )
 {
-   class Player* Player = new class Player( this->nextId++, position, size, speed );
-   this->allObjects.push_back( Player );
+   class Player* Player = new class Player( 0, position, size, speed ); //id for player is always 0
+   allObjects[Player->getId()] = Player; //add <id, object*> to the map
    this->numberOfObjects++;
    return Player;
 }


### PR DESCRIPTION
player object now moves between floors. objectHandlers changed to use std::map<int, GameObject*> instead of vectors. nextId is static across all objectHandlers. player coordinates don't change yet when changing floors so they can be in walls rn. need to move them to the floors spawn point when changing floors