### PR TITLE
fix audio not playing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,9 +55,9 @@ int main( )
    loadAllTextures( );
    screenHandler.cameras.push_back( &mainCamera );
 
-   MusicPlayer musicPlayer;
    StaticSprite background( "spaceBackground", { 320, 180 }, -9999999 );
    InitAudioDevice( );
+   MusicPlayer musicPlayer;
    musicPlayer.setVolume( 0.5f );
 
 


### PR DESCRIPTION
move musicPlayer to be created after InitAudioDevice() like it used to be, because I think they got swapped around at some point and it made the audio stopped working (at least on my pc)